### PR TITLE
Remove unnecessary <template> element in vue3 computed snippet

### DIFF
--- a/content/1-reactivity/3-computed-state/vue3/DoubleCount.vue
+++ b/content/1-reactivity/3-computed-state/vue3/DoubleCount.vue
@@ -4,7 +4,3 @@ const count = ref(10);
 const doubleCount = computed(() => count.value * 2);
 console.log(doubleCount.value); // 20
 </script>
-
-<template>
-  <div />
-</template>


### PR DESCRIPTION
# Reactivity

## Computed state

- The Vue3 snippet show an  unnecessary `<template>` "section" which make the snippet look more verbose than it should.
- Removing this section make a fairer comparison

```
<template>
    <div/>
</template>
```