### PR TITLE
feat: preact repl support

### DIFF
--- a/src/components/Section.astro
+++ b/src/components/Section.astro
@@ -9,6 +9,7 @@ import FRAMEWORKS from '../frameworks';
 import CodeViewer from "./CodeViewer.astro"
 import createVue3REPL from "../utils/createVue3REPL"
 import createSvelteREPL from "../utils/createSvelteREPL"
+import createReactREPL from "../utils/createReactREPL"
 
 const { path: sectionPath } = Astro.props
 
@@ -27,6 +28,7 @@ function capitalize(string) {
 
 const vue3REPL = createVue3REPL()
 const svelteREPL = createSvelteREPL()
+const reactREPL = createReactREPL()
 
 function generatePlaygroundURL(frameworkId, files){
   let playgroundURL
@@ -42,6 +44,13 @@ function generatePlaygroundURL(frameworkId, files){
       return acc
     }, {})
     playgroundURL = svelteREPL.fromContentByFilename(contentByFilename) 
+  } else if(frameworkId === "react"){
+    if (files.length > 1) return
+    const contentByFilename = files.reduce((acc, file) => {
+      acc[file.fileName] =  file.content
+      return acc
+    }, {})
+    playgroundURL = reactREPL.fromContentByFilename(contentByFilename) 
   }
    return playgroundURL
 }

--- a/src/utils/createReactREPL.js
+++ b/src/utils/createReactREPL.js
@@ -1,15 +1,8 @@
 import nodePath from 'path';
 
-export default function createSvelteREPL() {
-	const BASE_URL = 'https://svelte-repl.vercel.app/#';
-
-	function utoa(data) {
-		return btoa(unescape(encodeURIComponent(data)));
-	}
-
-	function generateURLFromData(data) {
-		return `${BASE_URL}${utoa(JSON.stringify(data))}`;
-	}
+// Preact repl currently only supports 1 file
+export default function createReactREPL() {
+	const BASE_URL = 'https://preactjs.com/repl';
 
 	function fromContentByFilename(contentByFilename) {
 		const data = [];
@@ -22,8 +15,7 @@ export default function createSvelteREPL() {
 				source: content,
 			});
 		}
-		const url = generateURLFromData(data);
-		return url;
+		return `${BASE_URL}?code=${encodeURIComponent(data[0].source)}`;
 	}
 
 	return {


### PR DESCRIPTION
So first of all, great little webapp! Love the idea and implementation!

Noticed there wasn't a React REPL linked though, and the upon further research I noticed why - there don't seem to really be any. At least not in the style of the svelte-repl and vue repl. Of course theres the codesandbox and codepen's of the world..

But I did find the Preact REPL which behaves almost exactly like the svelte and vue ones, and supports all the React sample code I could manually test!

What do you think, good enough for now?

Also the Preact repl doesn't have multi file support. So I ignored all React examples which contained more than 1 file for now. 