### PR TITLE
Proposal : Remove unnecessary useMemo in TrafficLight react example

### DIFF
--- a/content/2-templating/6-conditional/react/TrafficLight.jsx
+++ b/content/2-templating/6-conditional/react/TrafficLight.jsx
@@ -1,11 +1,11 @@
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 
 const TRAFFIC_LIGHTS = ['red', 'orange', 'green'];
 
 export default function TrafficLight() {
 	const [lightIndex, setLightIndex] = useState(0);
 
-	const light = useMemo(() => TRAFFIC_LIGHTS[lightIndex], [lightIndex]);
+	const light = TRAFFIC_LIGHTS[lightIndex];
 
 	function nextLight() {
 		if (lightIndex + 1 > TRAFFIC_LIGHTS.length - 1) {


### PR DESCRIPTION
It's more a question of taste, but I think it makes the example more concise