### PR TITLE
fix(lit): use reactive state on declare-state example

### DIFF
--- a/content/1-reactivity/1-declare-state/lit/index.html
+++ b/content/1-reactivity/1-declare-state/lit/index.html
@@ -3,5 +3,5 @@
 	<script type="module" src="./name.js"></script>
 </head>
 <body>
-	<name />
+	<x-name></x-name>
 </body>

--- a/content/1-reactivity/1-declare-state/lit/name.js
+++ b/content/1-reactivity/1-declare-state/lit/name.js
@@ -2,7 +2,7 @@ import { LitElement, html } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
 @customElement('x-name')
-export class Name extends LitElement {
+export class XName extends LitElement {
 	@state()
 	name = 'John';
 

--- a/content/1-reactivity/1-declare-state/lit/name.js
+++ b/content/1-reactivity/1-declare-state/lit/name.js
@@ -1,8 +1,9 @@
 import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 
-@customElement('name')
+@customElement('x-name')
 export class Name extends LitElement {
+	@state()
 	name = 'John';
 
 	render() {


### PR DESCRIPTION
This PR addresses a two things:

1. Other examples showcase _reactive_ state (`useState` in React, for example). The current example was not using reactive state. Using the `@state()` decorator makes this class field reactive (As internal state). `@property()` would also be valid but I think that's better for the `Component composition` section
2. Custom elements _must_ have a dash (`-`) in their name, so I changed it to `x-name` (`x` being a generic prefix that could be replaced by anything).
3. Custom elements cannot be self-closing AFAIK.