### PR TITLE
Correct Solid slot examples

### DIFF
--- a/content/4-component-composition/3-slot/solid/FunnyButton.jsx
+++ b/content/4-component-composition/3-slot/solid/FunnyButton.jsx
@@ -1,8 +1,4 @@
-import { children } from 'solid-js';
-
 export default function FunnyButton(props) {
-	const content = children(() => props.children);
-
 	return (
 		<button
 			style={{
@@ -18,7 +14,7 @@ export default function FunnyButton(props) {
 				outline: '0',
 			}}
 		>
-			{content()}
+			{props.children}
 		</button>
 	);
 }

--- a/content/4-component-composition/4-slot-fallback/solid/FunnyButton.jsx
+++ b/content/4-component-composition/4-slot-fallback/solid/FunnyButton.jsx
@@ -1,8 +1,4 @@
-import { children } from 'solid-js';
-
 export default function FunnyButton(props) {
-	const content = children(() => props.children);
-
 	return (
 		<button
 			style={{
@@ -18,7 +14,7 @@ export default function FunnyButton(props) {
 				outline: '0',
 			}}
 		>
-			{content() || <span>No content found</span>}
+			{props.children || <span>No content found</span>}
 		</button>
 	);
 }


### PR DESCRIPTION
In Solid, the `children` helper isn't required to place `props.children` in JSX. The slot examples in the content section could be written similarly to React. Minus the destructuring of course.
[some proof](https://playground.solidjs.com/?hash=432759760&version=1.4.1)
The purpose of `children` helper is to resolve all of the nested arrays/functions inside `props.children` to a flat array. This is so that they are easier to map, for example for [animating html elements](https://github.com/solidjs/solid-transition-group/blob/22739eddb2087597e183f0e47d3d3109c4af0c95/src/TransitionGroup.ts#L59).