### PR TITLE
add spans to svelte conditional templating

### DIFF
--- a/content/2-templating/6-conditional/svelte/TrafficLight.svelte
+++ b/content/2-templating/6-conditional/svelte/TrafficLight.svelte
@@ -18,10 +18,10 @@
 <p>
 	You must
 	{#if light === 'red'}
-		STOP
+		<span>STOP</span>
 	{:else if light === 'orange'}
-		SLOW DOWN
+		<span>SLOW DOWN</span>
 	{:else if light === 'green'}
-		GO
+		<span>GO</span>
 	{/if}
 </p>


### PR DESCRIPTION
The conditional templating example, all frameworks except Svelte have `<span>` tags wrapping the conditional templates.
For the sake of consistency when comparing syntaxes I think it is better to add spans to Svelte too.
I'm sure all of the other frameworks also have the ability to conditionally swap between plain text. Although probably with varying syntaxes. Maybe worth a separate example?