### PR TITLE
feat(lit): add router example

### DIFF
--- a/content/7-webapp-features/1-routing/lit/vaadin.md
+++ b/content/7-webapp-features/1-routing/lit/vaadin.md
@@ -1,0 +1,19 @@
+With [@vaadin/router](https://vaadin.com/router)
+
+```html
+<div id="outlet"></div>
+
+<script>
+  // import {Router} from '@vaadin/router'; // for Webpack / Polymer CLI
+  // const Router = Vaadin.Router; // for vaadin-router.umd.js
+
+  // select the DOM node where the router inserts route Web Components
+  const outlet = document.getElementById('outlet');
+  const router = new Router(outlet);
+  router.setRoutes([
+    {path: '/', component: 'x-home-view'},
+    {path: '/users', component: 'x-user-list'},
+    {path: '/users/:user', component: 'x-user-profile'},
+  ]);
+</script>
+```

--- a/content/7-webapp-features/1-routing/lit/vaadin.md
+++ b/content/7-webapp-features/1-routing/lit/vaadin.md
@@ -12,8 +12,7 @@ With [@vaadin/router](https://vaadin.com/router)
   const router = new Router(outlet);
   router.setRoutes([
     {path: '/', component: 'x-home-view'},
-    {path: '/users', component: 'x-user-list'},
-    {path: '/users/:user', component: 'x-user-profile'},
+    {path: '/about', component: 'x-about-view'},
   ]);
 </script>
 ```

--- a/content/7-webapp-features/2-router-link/lit/vaadin.md
+++ b/content/7-webapp-features/2-router-link/lit/vaadin.md
@@ -6,10 +6,7 @@ With [@vaadin/router](https://vaadin.com/router)
     <a href="/">Home</a>
   </li>
   <li>
-    <a href="/users">User list</a>
-  </li>
-  <li>
-    <a href="/users/1">Your profile</a>
+    <a href="/about">About us</a>
   </li>
 </ul>
 ```

--- a/content/7-webapp-features/2-router-link/lit/vaadin.md
+++ b/content/7-webapp-features/2-router-link/lit/vaadin.md
@@ -1,0 +1,15 @@
+With [@vaadin/router](https://vaadin.com/router)
+
+```html
+<ul>
+  <li>
+    <a href="/">Home</a>
+  </li>
+  <li>
+    <a href="/users">User list</a>
+  </li>
+  <li>
+    <a href="/users/1">Your profile</a>
+  </li>
+</ul>
+```


### PR DESCRIPTION
Me again!

Felt it looked a bit incomplete without a routing example so, even if it's not an "official" solution, I added an example with `@vaadin/router` which is a quite popular solution (and the most "kitchen sink" kind of solution I've found). I personally have used this library as well. The example itself I took out of the `Getting started` from its docs.

Other alternatives I've seen are either handling it as a multi-page app (multiple HTML files with the built-in browser navigation), or manually hooking into the `popstate` event to handle navigation events yourself. But this one is concise enough for a snippet, I feel.