### PR TITLE
feat(solid): add router example

### DIFF
--- a/content/7-webapp-features/1-routing/solid/solid-app-router.md
+++ b/content/7-webapp-features/1-routing/solid/solid-app-router.md
@@ -1,0 +1,26 @@
+With [solid-app-router](https://github.com/solidjs/solid-app-router)
+
+```jsx
+import { render } from "solid-js/web";
+import { Router, Routes, Route } from "solid-app-router";
+import About from "./About";
+import Home from "./Home";
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/about" element={<About />} />
+    </Routes>
+  );
+}
+
+render(
+  () => (
+    <Router>
+      <App />
+    </Router>
+  ),
+  document.getElementById("root")
+);
+```

--- a/content/7-webapp-features/2-router-link/solid/solid-app-router.md
+++ b/content/7-webapp-features/2-router-link/solid/solid-app-router.md
@@ -1,0 +1,22 @@
+With [solid-app-router](https://github.com/solidjs/solid-app-router)
+
+```jsx
+import { Link } from 'solid-app-router';
+
+export default function Home() {
+  return (
+    <ul>
+      <li>
+        <Link href="/">
+          Home
+        </Link>
+      </li>
+      <li>
+        <Link href="/about">
+          About us
+        </Link>
+      </li>
+    </ul>
+  );
+}
+```


### PR DESCRIPTION
Once more with an example for Solid. Using `solid-app-router`! Its syntax is similar to react-router-dom.