### PR TITLE
Update Solid.js TrafficLight example

### DIFF
--- a/content/2-templating/6-conditional/solid/TrafficLight.jsx
+++ b/content/2-templating/6-conditional/solid/TrafficLight.jsx
@@ -28,4 +28,3 @@ export default function TrafficLight() {
 		</>
 	);
 }
-				 

--- a/content/2-templating/6-conditional/solid/TrafficLight.jsx
+++ b/content/2-templating/6-conditional/solid/TrafficLight.jsx
@@ -1,4 +1,3 @@
-import { Switch, Match } from 'solid-js/web';
 import { createSignal } from 'solid-js';
 
 const TRAFFIC_LIGHTS = ['red', 'orange', 'green'];
@@ -22,18 +21,11 @@ export default function TrafficLight() {
 			<p>Light is: {light()}</p>
 			<p>
 				You must
-				<Switch>
-					<Match when={light() === 'red'}>
-						<span>STOP</span>
-					</Match>
-					<Match when={light() === 'orange'}>
-						<span>SLOW DOWN</span>
-					</Match>
-					<Match when={light() === 'green'}>
-						<span>GO</span>
-					</Match>
-				</Switch>
+				{light() === 'red' && <span> STOP</span>}
+				{light() === 'orange' && <span> SLOW DOWN</span>}
+				{light() === 'green' && <span> GO</span>}
 			</p>
 		</>
 	);
 }
+				 


### PR DESCRIPTION
This makes the example closer to the React one. Switch is an option, but probably unnecessary for this simple example. It makes more sense when you need the fallback/default option like a regular switch statement, or if you're matching on multiple conditions for one output.

Also, you should import from `solid-js`, not `solid-js/web` for most of the components.

Also see working example on the [Solid.js Playground](https://playground.solidjs.com/?version=1.4.1#NobwRAdghgtgpmAXGGUCWEwBowBcCeADgsrgM4Ae2YZA9gK4BOAxiWGjIbY7gAQi9GcCABM4jXgF9eAM0a0YvAOR0ANmhEBaAFZkA9AHc4AIyUBuADoQOXHv17MhUXHADKaAObRVU2fMUqtOpauuZWVsy0EGR8ACoASgCCAGLJAJIAwgD6ADJpAOIAErGuvAC8vMBKQiJKWMrcUBAecHXKHkLCSgC6lhBWcBS2fGIyUPSqfDL0EMy4aFG8sYxQMjJozDmeABa4ABQAlPzhuJHRfMDqHrtpooP1ZHC4W9e4t2IU3eUOTi7uXlBVHsAAwHPonM4xXhXXbfQ7lAB8SySqUyuQKxVclx2bzuFEOvXC-Vw01m80WEEGzxx8JAJws8xkvD2MNxH3hAGpeABGXhIhIpdLZPJFEoAOlUwg8uG2vE0PKOdOJDIZj2pr3egxBYPpuGkcFUj2OytwqqeLxueJZOM1+KOXO5OpNkhOLv6xKEuCYEGZuoAPAjdQy-cZ6LhcIsohl1MwANZlECUijq3aSBEAOSp0Jxfr0ofDUUDJuDhARFr4aDIiH4rMOklzpaDuD9jeLptwAE0GLwYPQYk2GSBa0cyqPlDUlLwAGRT3h+siEJpI1yxADyAAVcwul26Ve3B8PymOlI1mq1p7P54uIMucquAOq8AAiD-TW+vCN3+-bQ5pI+PHRwF0F5ztuN68Pkq7vjuTYNkWe65vBuBOm6Qh3IwezwmUSJ+ssqzrJsOK8HoCL1CItDMPQ8AQLgYrGLQIj4GCYCSN0QA).

I see that you have repl links from the Svelte examples, you could have similar ones for Solid.js via it's playground: https://playground.solidjs.com/