### PR TITLE
Remove useMemo for simple calculation

### DIFF
--- a/content/1-reactivity/3-computed-state/react/DoubleCount.jsx
+++ b/content/1-reactivity/3-computed-state/react/DoubleCount.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 
 export default function DoubleCount() {
 	const [count] = useState(10);
-	const doubleCount = useMemo(() => count * 2, [count]);
+	const doubleCount = count * 2;
 
 	return <div>{doubleCount}</div>;
 }


### PR DESCRIPTION
It's not idiomatic to use useMemo for such a cheap calculation.
https://canimerge.com/should-you-really-use-usememo-in-react-lets-find-out/
https://blog.logrocket.com/rethinking-hooks-memoization/