### PR TITLE
fix(svelte): update sveltekit routing fs example

### DIFF
--- a/content/7-webapp-features/3-routing/svelte/sveltekit.md
+++ b/content/7-webapp-features/3-routing/svelte/sveltekit.md
@@ -2,8 +2,9 @@ With <a href="https://kit.svelte.dev/docs/routing#pages">SvelteKit</a>
 
 ```
 |-- routes/
-    |-- index.svelte // index page "/"
-    |-- about.svelte // about page "/about"
-    |-- __error.svelte // handle HTTP errors 404, 500,...
-    |-- __layout.svelte // global app layout
+    |-- +page.svelte // index page "/"
+    |-- about/
+        |-- +page.svelte // about page "/about"
+    |-- +error.svelte // handle HTTP errors 404, 500,...
+    |-- +layout.svelte // global app layout
 ```


### PR DESCRIPTION
Updates the SvelteKit routing section to reflect new changes in the framework in version 1.0.0-next.406.