### PR TITLE
feat(qwik): add input focused example

### DIFF
--- a/content/2-templating/5-dom-ref/qwik/InputFocused.tsx
+++ b/content/2-templating/5-dom-ref/qwik/InputFocused.tsx
@@ -1,0 +1,9 @@
+import { component$, useClientEffect$, useRef } from '@builder.io/qwik';
+
+export const InputFocused = component$(() => {
+	const inputElement = useRef(null);
+
+	useClientEffect$(() => inputElement.current.focus());
+
+	return <input type="text" ref={inputElement} />;
+});

--- a/src/frameworks.mjs
+++ b/src/frameworks.mjs
@@ -175,17 +175,17 @@ export default [
 				es2021: true,
 				node: true,
 			},
+			parser: '@typescript-eslint/parser',
 			parserOptions: {
 				ecmaFeatures: {
-				  jsx: true,
+					jsx: true,
 				},
-			  },
+			},
 			files: ['**/qwik/**'],
-			extends: ['eslint:recommended',
-			'plugin:qwik/recommended'],
+			extends: ['eslint:recommended', 'plugin:qwik/recommended'],
 			rules: {
-				'qwik/valid-lexical-scope': 'off'
-			}
+				'qwik/valid-lexical-scope': 'off',
+			},
 		},
 		playgroundURL: 'https://qwik.builder.io/playground',
 		documentationURL: 'https://qwik.builder.io/docs/overview',


### PR DESCRIPTION
Adds the "Dom ref" Qwik implementation featuring Input Focus.