### PR TITLE
feat(qwik): add page title example

### DIFF
--- a/content/3-lifecycle/1-on-mount/qwik/PageTitle.tsx
+++ b/content/3-lifecycle/1-on-mount/qwik/PageTitle.tsx
@@ -1,0 +1,13 @@
+import { component$, useClientEffect$, useStore } from '@builder.io/qwik';
+
+export const App = component$(() => {
+	const store = useStore({
+		pageTitle: '',
+	});
+
+	useClientEffect$(() => {
+		store.pageTitle = document.title;
+	});
+
+	return <p>Page title: {store.pageTitle}</p>;
+});

--- a/src/frameworks.mjs
+++ b/src/frameworks.mjs
@@ -175,17 +175,17 @@ export default [
 				es2021: true,
 				node: true,
 			},
+			parser: '@typescript-eslint/parser',
 			parserOptions: {
 				ecmaFeatures: {
-				  jsx: true,
+					jsx: true,
 				},
-			  },
+			},
 			files: ['**/qwik/**'],
-			extends: ['eslint:recommended',
-			'plugin:qwik/recommended'],
+			extends: ['eslint:recommended', 'plugin:qwik/recommended'],
 			rules: {
-				'qwik/valid-lexical-scope': 'off'
-			}
+				'qwik/valid-lexical-scope': 'off',
+			},
 		},
 		playgroundURL: 'https://qwik.builder.io/playground',
 		documentationURL: 'https://qwik.builder.io/docs/overview',


### PR DESCRIPTION
Adds the "On mount" Qwik implementation featuring Page Title.