### PR TITLE
Feature: added framework selection in url

### DIFF
--- a/src/components/scripts/alpine-init.js
+++ b/src/components/scripts/alpine-init.js
@@ -2,6 +2,7 @@ import Alpine from 'alpinejs';
 
 Alpine.store('frameworksSelected', {
 	_frameworksSelectedProxy: createLocaleStorageProxy('frameworks_display'),
+	_urlStorage: createUrlStorage('f'),
 	_selectedIds: [],
 	init() {
 		// set default value of frameworksSelectedProxy
@@ -11,7 +12,8 @@ Alpine.store('frameworksSelected', {
 				this._frameworksSelectedProxy[i] = initialFrameworkIds[i];
 			}
 		}
-		this._selectedIds = [...this._frameworksSelectedProxy];
+		const frameworksFromUrl = this._urlStorage.get();
+		this._selectedIds = frameworksFromUrl.length ? [...frameworksFromUrl] : [...this._frameworksSelectedProxy];
 	},
 	has(fmwId) {
 		return this._selectedIds.includes(fmwId);
@@ -24,6 +26,8 @@ Alpine.store('frameworksSelected', {
 			const frameworkIndex = this._frameworksSelectedProxy.indexOf(fmwId);
 			delete this._frameworksSelectedProxy[frameworkIndex];
 		}
+
+		this._urlStorage.set(this._frameworksSelectedProxy);
 		this._selectedIds = [...this._frameworksSelectedProxy];
 	},
 	show(fmwId) {
@@ -31,6 +35,7 @@ Alpine.store('frameworksSelected', {
 			this._frameworksSelectedProxy.push(fmwId);
 		}
 
+		this._urlStorage.set(this._frameworksSelectedProxy);
 		this._selectedIds = [...this._frameworksSelectedProxy];
 	},
 });
@@ -81,6 +86,21 @@ function createLocaleStorage(k) {
 		},
 		remove() {
 			localStorage.removeItem(k);
+		},
+	};
+}
+
+function createUrlStorage(k) {
+	return {
+		get() {
+			const url = new URL(window.location.href);
+			const frameworkQuery = url.searchParams.get(k);
+			return frameworkQuery ? frameworkQuery.split('-') : [];
+		},
+		set(ids) {
+			const url = new URL(window.location.href);
+			url.searchParams.set(k, ids.join('-'));
+			window.history.replaceState(null, document.title, url.toString());
 		},
 	};
 }


### PR DESCRIPTION
### Preface

I wanted to share a link to component-party.dev highlighting a difference between two frameworks. But there is no way to transfer the selected frameworks via url.

### Proposed Solution
[https://component-party.dev/?f=react-angular#minimal-template](https://component-party.dev/?f=react-angular#minimal-template)

### Changes
- added url search parameter `?f=svelte-react`
- combined local storage with url 'storage':
    - initial load with local storage and url prefers url parameters (localstorage is only overwritten after framework selection change)
    - change of selected frameworks updates local storage + url
- url-safe dash separator (, got url-safe encoded)
- works together with [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)

### Discussion Points

- list separator (`-` for now)
- search parameter name (`?f=` as shorthand)
- search parameter/local storage synchronization
- history updating (using replaceState)