### PR TITLE
Simplify InputFocused.svelte

### DIFF
--- a/content/2-templating/5-dom-ref/svelte/InputFocused.svelte
+++ b/content/2-templating/5-dom-ref/svelte/InputFocused.svelte
@@ -3,9 +3,7 @@
 
 	let inputElement;
 
-	onMount(() => {
-		inputElement.focus();
-	});
+	onMount(() => inputElement.focus());
 </script>
 
 <input bind:this={inputElement} />


### PR DESCRIPTION
React version seems shorter just because the arrow function is one lined, obviously we can do the same in svelte.