### PR TITLE
Added syntax highlighting for angular component templates

### DIFF
--- a/content/1-reactivity/1-declare-state/angular/name.component.ts
+++ b/content/1-reactivity/1-declare-state/angular/name.component.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-name",
-  template: "<h1>Hello {{ name }}</h1>",
+  template: `<h1>Hello {{ name }}</h1>`,
 })
 export class NameComponent {
   name = "John";

--- a/content/1-reactivity/2-update-state/angular/name.component.ts
+++ b/content/1-reactivity/2-update-state/angular/name.component.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-name",
-  template: "<h1>Hello {{ name }}</h1>",
+  template: `<h1>Hello {{ name }}</h1>`,
 })
 export class NameComponent {
   name = "John";

--- a/content/1-reactivity/3-computed-state/angular/doublecount.component.ts
+++ b/content/1-reactivity/3-computed-state/angular/doublecount.component.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-doublecount",
-  template: "<div>{{ doubleCount }}</div>",
+  template: `<div>{{ doubleCount }}</div>`,
 })
 export class DoublecountComponent {
   count = 10;

--- a/content/2-templating/1-minimal-template/angular/helloworld.component.ts
+++ b/content/2-templating/1-minimal-template/angular/helloworld.component.ts
@@ -2,6 +2,6 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-helloworld",
-  template: "<h1>Hello world</h1>",
+  template: `<h1>Hello world</h1>`,
 })
 export class HelloworldComponent {}

--- a/content/3-lifecycle/1-on-mount/angular/pagetitle.component.ts
+++ b/content/3-lifecycle/1-on-mount/angular/pagetitle.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from "@angular/core";
 
 @Component({
   selector: "app-pagetitle",
-  template: "<p>Page title: {{ pageTitle }}</p>",
+  template: `<p>Page title: {{ pageTitle }}</p>`,
 })
 export class PagetitleComponent implements OnInit {
   pageTitle = "";

--- a/content/3-lifecycle/2-on-unmount/angular/time.component.ts
+++ b/content/3-lifecycle/2-on-unmount/angular/time.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy } from "@angular/core";
 
 @Component({
   selector: "app-time",
-  template: "<p>Current time: {{ time }}</p>",
+  template: `<p>Current time: {{ time }}</p>`,
 })
 export class TimeComponent implements OnDestroy {
   time: string = new Date().toLocaleTimeString();

--- a/content/4-component-composition/3-slot/angular/app.component.ts
+++ b/content/4-component-composition/3-slot/angular/app.component.ts
@@ -2,6 +2,6 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-root",
-  template: "<app-funny-button>Click me !</app-funny-button>",
+  template: `<app-funny-button>Click me !</app-funny-button>`,
 })
 export class AppComponent {}

--- a/content/6-form-input/1-input-text/angular/input-hello.component.ts
+++ b/content/6-form-input/1-input-text/angular/input-hello.component.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 
 @Component({
   selector: "app-input-hello",
-  template: '<input [value]="text" (change)="handleInputChange($event)" />',
+  template: `<input [value]="text" (change)="handleInputChange($event)" />`,
 })
 export class InputHelloComponent {
   text = "";

--- a/content/7-webapp-features/3-routing/angular/app.module.ts
+++ b/content/7-webapp-features/3-routing/angular/app.module.ts
@@ -1,17 +1,7 @@
 import { RouterModule } from "@angular/router";
 import { NgModule, Component } from "@angular/core";
-
-@Component({
-  selector: "app-home",
-  template: "<h1>Home page</h1>",
-})
-export class HomeComponent {}
-
-@Component({
-  selector: "app-about",
-  template: "<h1>About page</h1>",
-})
-export class AboutComponent {}
+import { HomeComponent } from "./home.component";
+import { AboutComponent } from "./about.component";
 
 @Component({
   selector: "app-root",

--- a/src/components/CodeHighlight/highlightAngularComponent.js
+++ b/src/components/CodeHighlight/highlightAngularComponent.js
@@ -1,0 +1,69 @@
+import astroHighlightCode from "@/components/CodeHighlight/astroHighlightCode.js";
+
+export async function highlightAngularComponent(
+  fileContent,
+  theme,
+  wrap,
+  fileExt
+) {
+  const templateCode = getAngularTemplateCode(fileContent);
+
+  if (!templateCode) return fileContent;
+
+  const componentWithEmptyTemplate = removeAngularTemplateContent(fileContent);
+
+  let templateCodeHighlighted = await astroHighlightCode({
+    code: templateCode,
+    lang: "html",
+    theme,
+    wrap,
+  });
+
+  let componentHighlighted = await astroHighlightCode({
+    code: componentWithEmptyTemplate,
+    lang: fileExt,
+    theme,
+    wrap,
+  });
+
+  return componentHighlighted.replace(
+    "template",
+    "template: `" + removeCodeWrapper(templateCodeHighlighted) + "`,"
+  );
+}
+
+function getAngularTemplateCode(fileContent) {
+  // regex to grab whats inside angular component template inside backticks
+  const regex = /template:\s*`([\s\S]*?)`/gm;
+
+  // grab the template string
+  const template = regex.exec(fileContent);
+
+  if (template) return template[1];
+
+  return "";
+}
+
+function removeAngularTemplateContent(fileContent) {
+  let componentWithoutContentInsideTemplate = fileContent.replace(
+    /template:\s*`([\s\S]*?)([^*])`,?/gm,
+    "template"
+  );
+
+  return componentWithoutContentInsideTemplate;
+}
+
+function removeCodeWrapper(html) {
+  html = html.replace(
+    '<pre is:raw class="astro-code" style="background-color: #0d1117; overflow-x: auto;"><code>',
+    ""
+  );
+  return html.replace("</code></pre>", "");
+}
+
+export function isAngularComponent(fileContent) {
+  return (
+    fileContent.includes('from "@angular/core"') &&
+    fileContent.includes("template:")
+  );
+}

--- a/src/components/CodeHighlight/highlightAngularComponent.js
+++ b/src/components/CodeHighlight/highlightAngularComponent.js
@@ -33,7 +33,7 @@ export async function highlightAngularComponent(
 }
 
 function getAngularTemplateCode(fileContent) {
-  // regex to grab whats inside angular component template inside backticks
+  // regex to grab what is inside angular component template inside backticks
   const regex = /template:\s*`([\s\S]*?)`/gm;
 
   // grab the template string
@@ -54,16 +54,13 @@ function removeAngularTemplateContent(fileContent) {
 }
 
 function removeCodeWrapper(html) {
-  html = html.replace(
-    '<pre is:raw class="astro-code" style="background-color: #0d1117; overflow-x: auto;"><code>',
-    ""
-  );
-  return html.replace("</code></pre>", "");
+  let regexForWrapper = /<pre([\s\S]*?)><code>([\s\S]*?)<\/code><\/pre>/gm;
+  let code = regexForWrapper.exec(html);
+  return code[2];
 }
 
 export function isAngularComponent(fileContent) {
   return (
-    fileContent.includes('from "@angular/core"') &&
-    fileContent.includes("template:")
+    fileContent.includes("@angular/core") && fileContent.includes("template")
   );
 }

--- a/src/components/FileCode.astro
+++ b/src/components/FileCode.astro
@@ -4,6 +4,7 @@ import nodePath from "node:path";
 import { createFileMapCache } from "micache";
 
 import astroHighlightCode from "@/components/CodeHighlight/astroHighlightCode.js";
+import { highlightAngularComponent, isAngularComponent } from "@/components/CodeHighlight/highlightAngularComponent.js";
 
 const { path, lang, theme = "github-dark", wrap = false } = Astro.props;
 
@@ -13,15 +14,22 @@ await fs.access(path);
 const fileCodeCache = await createFileMapCache("fileCodeCache");
 
 let html = await fileCodeCache.get(path);
+
 if (!html) {
   const fileExt = nodePath.parse(path).ext.split(".").pop();
   const fileContent = await fs.readFile(path, "utf-8");
-  html = await astroHighlightCode({
-    code: fileContent,
-    lang: lang || fileExt,
-    theme,
-    wrap,
-  });
+
+  if (isAngularComponent(fileContent)) {
+    html = await highlightAngularComponent(fileContent, theme, wrap,  lang || fileExt);
+  } else {
+    html = await astroHighlightCode({
+      code: fileContent,
+      lang: lang || fileExt,
+      theme,
+      wrap,
+    });
+  }
+
   fileCodeCache.set(path, html);
 }
 ---


### PR DESCRIPTION
This PR resolves this issue: [Code highlight for Angular inline template and styles](https://github.com/matschik/component-party/issues/100)

Example:

Before: 
![image](https://user-images.githubusercontent.com/25394362/201064034-d83f7c08-b3ad-4dfa-aac6-67edf4a2a8d5.png)

After: 
<img width="981" alt="Screenshot 2022-11-10 at 11 14 54 AM" src="https://user-images.githubusercontent.com/25394362/201064105-1504fec8-e1ea-432b-a314-55c8287a50b0.png">


NOTE: 
I had to convert all Angular templates to use `` (backticks) in order to grab them easily with regex and do the replacements. 