### PR TITLE
Update nextjs.md

### DIFF
--- a/content/7-webapp-features/2-router-link/react/nextjs.md
+++ b/content/7-webapp-features/2-router-link/react/nextjs.md
@@ -7,14 +7,10 @@ export default function Home() {
   return (
     <ul>
       <li>
-        <Link href="/">
-          <a>Home</a>
-        </Link>
+        <Link href="/">Home</Link>
       </li>
       <li>
-        <Link href="/about">
-          <a>About us</a>
-        </Link>
+        <Link href="/about">About us</Link>
       </li>
     </ul>
   );


### PR DESCRIPTION
Starting from Next.js 13, the link component no longer needs an anchor tag inside it. https://nextjs.org/docs/api-reference/next/link