### PR TITLE
Improve readability of FunnyButton.svelte

### DIFF
--- a/content/4-component-composition/3-slot/svelte/FunnyButton.svelte
+++ b/content/4-component-composition/3-slot/svelte/FunnyButton.svelte
@@ -1,5 +1,18 @@
-<button
-  style="background: rgba(0, 0, 0, 0.4); color: #fff; padding: 10px 20px; font-size: 30px; border: 2px solid #fff; margin: 8px; transform: scale(0.9); box-shadow: 4px 4px rgba(0, 0, 0, 0.4); transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s; outline: 0;"
->
+<button>
   <slot />
 </button>
+
+<style>
+  button {
+    background: rgba(0, 0, 0, 0.4);
+    color: #fff;
+    padding: 10px 20px;
+    font-size: 30px;
+    border: 2px solid #fff;
+    margin: 8px;
+    transform: scale(0.9);
+    box-shadow: 4px 4px rgba(0, 0, 0, 0.4);
+    transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s;
+    outline: 0;
+  }
+</style>

--- a/content/4-component-composition/4-slot-fallback/svelte/FunnyButton.svelte
+++ b/content/4-component-composition/4-slot-fallback/svelte/FunnyButton.svelte
@@ -1,7 +1,20 @@
-<button
-  style="background: rgba(0, 0, 0, 0.4); color: #fff; padding: 10px 20px; font-size: 30px; border: 2px solid #fff; margin: 8px; transform: scale(0.9); box-shadow: 4px 4px rgba(0, 0, 0, 0.4); transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s; outline: 0;"
->
+<button>
   <slot>
     <span>No content found</span>
   </slot>
 </button>
+
+<style>
+  button {
+    background: rgba(0, 0, 0, 0.4);
+    color: #fff;
+    padding: 10px 20px;
+    font-size: 30px;
+    border: 2px solid #fff;
+    margin: 8px;
+    transform: scale(0.9);
+    box-shadow: 4px 4px rgba(0, 0, 0, 0.4);
+    transition: transform 0.2s cubic-bezier(0.34, 1.65, 0.88, 0.925) 0s;
+    outline: 0;
+  }
+</style>


### PR DESCRIPTION
The svelte example for FunnyButton.svelte was small but was not readable. Having all styles in one line is not very pretty.

This PR splits it off into a style block, which is much more readable.