### PR TITLE
Update Lit's computed state snippet to not create a public field.

### DIFF
--- a/content/1-reactivity/3-computed-state/lit/double-count.js
+++ b/content/1-reactivity/3-computed-state/lit/double-count.js
@@ -6,11 +6,8 @@ export class DoubleCount extends LitElement {
   @state()
   count = 10;
 
-  get doubleCount() {
-    return this.count * 2;
-  }
-
   render() {
-    return html`<div>${this.doubleCount}</div>`;
+    const doubleCount = this.count * 2;
+    return html`<div>${doubleCount}</div>`;
   }
 }


### PR DESCRIPTION
If you don't need state to be accessed publicly or in multiple methods, you can just use statements in the render() method.