### PR TITLE
Fix scrolling in Firefox

### DIFF
--- a/src/Index.svelte
+++ b/src/Index.svelte
@@ -49,7 +49,6 @@
   const siteTitle = "Component Party";
 
   const unsubscribeCurrentRoute = currentRoute.subscribe(($currentRoute) => {
-    window.scrollTo(0, 0);
     isVersusFrameworks = false;
     document.title = siteTitle;
 


### PR DESCRIPTION
Closes #226 

By removing the `scrollTo(0,0)` in Index.svelte for `unsubscribeCurrentRoute` it seems like scrolling in Firefox is fixed.

My guess is that in Firefox this `scrollTo` 'wins', whereas in Chromium the hash wins.

I'm not sure if this `scrollTo` was doing any heavy lifting; a cursory glance showed that most things still seem to work, but as I'm not the original author I'm not sure why this was in there. 

As such it is highly possible that I just accidentally removed Chesterton's Fence, but I felt this was at least worth putting out there :)