### PR TITLE
Account for header bar in scroll target offsets

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -11,3 +11,6 @@
 .no-scroll::-webkit-scrollbar {
   display: none; /* Chrome, Safari and Opera */
 }
+html {
+  scroll-padding-top: 60px; /* Approximate Header height with a horizontal scrollbar. */
+}


### PR DESCRIPTION
Prevents sticky headings from covering framework names when navigating to a component via the sidebar.

|Before|After
|-|-
|![before, without scrollbar](https://github.com/user-attachments/assets/a60365b9-7dbc-4e88-8604-ced1405facf0)|![after, without scrollbar](https://github.com/user-attachments/assets/099e0b95-960e-4cf0-9727-863c1b659e70)
|![before, with scrollbar](https://github.com/user-attachments/assets/1e399b78-fe23-4893-a441-2e9aecd2f50a)|![after, with scrollbar](https://github.com/user-attachments/assets/6a048ff9-6b3e-44ce-b315-7cf1c668a4fa)
